### PR TITLE
Allow NA expr

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -256,7 +256,7 @@ feat <- function(obj, features, fast=NULL, verbose=TRUE, ...) {
     } else {
       dat$expr <- ifelse(dat$expr > 0,
                          dat$expr,
-                         min(dat$expr[dat$expr>0])/10)
+                         min(dat$expr[dat$expr>0])/10, na.rm = TRUE)
     }
     p <- ggplot(dat,
            aes_string(x = "X1", y = "X2", col = "expr")) +


### PR DESCRIPTION
I had one data set in which totalUMIs were 0 for some cells. This led to NAs for ALL CELLS WITH 0 UMIs. Here I fix this with min(..., na.rm=TRUE).